### PR TITLE
adjustments on @albertmeronyo 's changed

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,7 +138,7 @@
               Team Contacts
             </th>
             <td>
-              Pierre-Antoine Champin (0.15 <abbr title="Full-Time Equivalent">FTE</abbr>)
+              Pierre-Antoine Champin (0.1 <abbr title="Full-Time Equivalent">FTE</abbr>)
             </td>
           </tr>
           <tr>

--- a/index.html
+++ b/index.html
@@ -80,13 +80,10 @@
       <!-- the link to the group is ALWAYS that available from https://www.w3.org/groups/wg or https://www.w3.org/groups/ig because each group page can then point to a different homepage, but not the other way around. -->
 
       <ul>
-        <li>Develop a W3C Recommendation for the Vocabulary Description Vocabulary (VVD, pronounced “Vivid”) for the interoperable exchange of dataset variable information on the Web.</li>
-        <li>Publish technical notes on bindings between VVD and other related W3C and non-W3C standards (DDI-CDI, RDF Data Cube, COW, SSN/SOSA, R2ML, etc).</li>
-        <li>Establish a list of use cases for the use of VVD, possibly in combination with related standards.</li>
-        <li>Maintain and revise the Data Catalog Vocabulary, DCAT, taking into account feature requests from the DCAT user community.</li>    
-        <li>Metadata for DCAT</li>
+        <li>Develop a W3C Recommendation for the interoperable exchange of dataset variable information on the Web.</li>
         <li>Maintain and revise the RDF Data Cube Vocabulary, QB, taking into account feature requests from the QB user community.</li>    
-        <li>Maintain and revise the Content Negotiation by Profile recommendation.</li>
+        <li>Maintain and revise the Data Catalog Vocabulary, DCAT, taking into account feature requests from the DCAT user community.</li>
+        <li>Define and publish guidance on the specification and use of application profiles when requesting and serving data on the Web.</li></ul>
       </ul>
 	    
       <div class="noprint">

--- a/index.html
+++ b/index.html
@@ -105,7 +105,7 @@
               Charter Status
             </th>
             <td>
-              See the <a href="https://www.w3.org/groups/wg/dx/charters/">group status page</A> and <a href="#history">detailed change history</a>.
+              See the <a href="https://www.w3.org/groups/wg/dx/charters/">group status page</a> and <a href="#history">detailed change history</a>.
             </td>
           </tr>
           <tr id="Duration">
@@ -113,7 +113,7 @@
               Start date
             </th>
             <td>
-              2025-07-01	
+              <i class="todo">[dd monthname yyyy] (date of the "Call for Participation", when the charter is approved)</i>
             </td>
           </tr>
           <tr id="CharterEnd">
@@ -121,7 +121,7 @@
               End date
             </th>
             <td>
-              2027-06-30	
+              <i class="todo">[dd monthname yyyy] (date of the "Call for Participation", when the charter is approved)</i>
             </td>
           </tr>
           <tr>


### PR DESCRIPTION
* simplify mission statement
* dates will be fixed when the charter is approved
* I will actually be involved 0.1 FTE

About the mission statement:
* I would keep the mission statement tight and high level; I took out the different items about VVD,
   and will put them further down the charter (deliverables) in a later PR

* Profile based content-negociation is not yet a REC, so the group is not just going to "maintain and revise it".
   Also, people will use [htmldiff](https://services.w3.org/htmldiff) to compare the old and new charter, so better keep the old items as unchanged as possible (unless of course we want to change hem)

* I'm not sure what the item "Metadata for DCAT" in the mission statement was supposed to mean...

@FranckCo I could not request a review from you, I'm not sure why...