### PR TITLE
First full draft of recharter

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,33 +158,32 @@
       <div id="background" class="background">
         <h2>Motivation and Background</h2>
 
-        <p class=todo>UPDATE THIS SECTION</p>
+        <!-- <p class=todo>UPDATE THIS SECTION</p>
         <ul class=todo>
           <li>Update history to include the publication of DCAT-3
           <li>Make it generally shorter
           <li>Include the motivation for VVD and adopting DataCube
-        </ul>
+        </ul> -->
 
-        <p>Sharing data among researchers, governments and citizens, whether openly or not, requires the provision of metadata. Different communities use different metadata standards to describe their datasets, some of which are highly specialized. At a general level W3C’s Data Catalog Vocabulary, <a href="https://www.w3.org/TR/vocab-dcat/">DCAT</a>, is in widespread use, but so too are <a href="https://ckan.org/">CKAN</a>’s native schema, schema.org's <a href="http://schema.org/Dataset">dataset description</a> vocabulary, <a href="http://www.iso.org/iso/catalogue_detail?csnumber=26020">ISO 19115</a>, <a href="http://www.ddialliance.org/explore-documentation">DDI</a>, <a href="https://sdmx.org/">SDMX</a>, <a href="http://www.eurocris.org/cerif/main-features-cerif">CERIF</a>, <a href="https://www.w3.org/TR/void/" title="Describing Linked Datasets with the VoID Vocabulary">VoID</a>, <a href="http://inspire.ec.europa.eu/index.cfm/pageid/101">INSPIRE</a> and, in the healthcare and life sciences domain, the <a href="https://www.w3.org/TR/hcls-dataset/">Dataset Description vocabulary</a> and <a href="https://github.com/biocaddie/WG3-MetadataSpecifications">DATS</a> (<a href="https://doi.org/10.1101/103143" title="DATS: the data tag suite to enable discoverability of datasets">ref</a>) among others.  This variety is a clear indication that no single vocabulary offers a complete and universally accepted solution. </p>
+        <p>Sharing data among researchers, governments and citizens, whether openly or not, requires the provision of metadata. Different communities use different metadata standards to describe their datasets, some of which are highly specialized. At a general level W3C’s Data Catalog Vocabulary, <a href="https://www.w3.org/TR/vocab-dcat/">DCAT</a>, is in widespread use, but so too are <a href="https://ckan.org/">CKAN</a>’s native schema, schema.org's <a href="http://schema.org/Dataset">dataset description</a> vocabulary, <a href="http://www.iso.org/iso/catalogue_detail?csnumber=26020">ISO 19115</a>, <a href="http://www.ddialliance.org/explore-documentation">DDI</a>, <a href="https://sdmx.org/">SDMX</a>, <a href="http://www.eurocris.org/cerif/main-features-cerif">CERIF</a>, <a href="https://www.w3.org/TR/void/" title="Describing Linked Datasets with the VoID Vocabulary">VoID</a>, <a href="http://inspire.ec.europa.eu/index.cfm/pageid/101">INSPIRE</a> and, in the healthcare and life sciences domain, the <a href="https://www.w3.org/TR/hcls-dataset/">Dataset Description vocabulary</a> and <a href="https://github.com/biocaddie/WG3-MetadataSpecifications">DATS</a> (<a href="https://doi.org/10.1101/103143" title="DATS: the data tag suite to enable discoverability of datasets">ref</a>) among others. The machine learning, AI, and scientific data communities have recently proposed <a href="https://mlcommons.org/working-groups/data/croissant/">Croissant</a> and <a href="https://www.researchobject.org/ro-crate/">RO-Crates</a> for similar purposes. This variety is a clear indication that no single vocabulary offers a complete and universally accepted solution. </p>
 
-        <p>DCAT has known gaps in coverage, for example around time series and versions. DCAT has been successful and is in wide use, but these gaps must be addressed if usage is to continue to grow across different communities and the variety of metadata schemas is to reduce.</p>
+        <p>A success of a previous WG charter was the publication of DCAT-3, where the evolved through multiple drafts to improve clarity, extend functionality, and align with best practices by introducing dataset series as first-class entities, refining versioning and inverse property handling, enhancing multilingual and accessibility support, improving alignment with external standards, and strengthening guidance on security, privacy, and metadata usage. </p>
 
-        <p>Maximizing interoperability between services such as data catalogs, e-Infrastructures and virtual research environments requires not just the use of standard vocabularies but of <em>application profiles</em>. These define how a vocabulary is used, for example by providing cardinality constraints and/or enumerated lists of allowed values such that data can be validated. The development of several application profiles based on DCAT, such as the European Commission's <a href="https://joinup.ec.europa.eu/asset/dcat_application_profile/description">DCAT-AP</a> is particularly noteworthy in this regard.</p>
-        <p>Rather than limit the number of metadata standards and application profiles in use, systems should be able to expose and ingest (meta)-data according to multiple standards through transparent and sustainable interfaces. We thus need a mechanism for servers to indicate the available standards and application profiles, and for clients to choose an appropriate one. This leads to the concept of content negotiation by application profile, which is orthogonal to content negotiation by data format and language that is already part of HTTP. A new <a href="https://profilenegotiation.github.io/I-D-Profile-Negotiation/I-D-Profile-Negotiation">Internet Draft on profile negotiation</a> currently under development at IETF with input from the Dataset Exchange Working Group, is based on the <a href="http://profilenegotiation.github.io/I-D-Accept--Schema/I-D-accept-schema"> draft</a> presented at the <a href="https://www.w3.org/2016/11/sdsvoc/report#conneg">SDSVoc workshop</a>. The combination of DXWG's definition of what is meant by "application profile", together with the DXWG view of how clients and servers may interact in different ways based on these profiles, together with this external work will provide a powerful means to exchange data in any format (JSON, RDF, XML etc.) according to declared structures against which the data can be validated.</p>
-        <p>The goals of the working group are to maintain the version 2 of DCAT and extend the standard to version 3 in line with work done to date and the ongoing work on dataset exchange being undertaken by communities more generally, and to develop to a recommendation the work undertaken in the 2017-2019 charter period on content negotiation by profile.</p>
+        <p>However, despite previous improvements around time series and versions, DCAT has known gaps in coverage, for example in describing the variables encoded within datasets in an explicitily and semantically interoperable manner. Variables are a fundamental concept in both dataset design and dataset search, partly covered in existing recommendations like the <a href="https://www.w3.org/TR/tabular-metadata/">Metadata Vocabulary for Tabular Data</a> (used to annotate tabular data) and the <a href="https://www.w3.org/TR/vocab-data-cube/">RDF Data Cube Vocabulary</a> (used to describe statistical data and time series). While these recommendations have been successful and are in wide use, this gap must be addressed if usage is to continue to grow across different communities and the variety of metadata schemas is to reduce.</p>
+
+        <p>The goals of the working group are to develop a new model for machine-actionable and interoperable dataset variable specifications, extending DCAT and QB for compatibility; as well as to maintain the version 3 of DCAT and the <a href="https://www.w3.org/TR/vocab-data-cube/">RDF Data Cube Vocabulary</a> (QB), as these vocabularies are key components of the W3C's approach to dataset exchange and their maintenance is essential for ensuring their relevance and usefulness to the community. </p>
       </div>
 
       <section id="scope" class="scope">
         <h2>Scope</h2>
         
-        <p class=todo>UPDATE THIS SECTION</p>
+        <!-- <p class=todo>UPDATE THIS SECTION</p>
         <ul class=todo>
           <li>Scope should be <em>much</em> shorter and generic (the specifics are given in the deliverable section)
           <li>In particular, input documents should <em>not</em> be listed here
-        </ul>
+        </ul> -->
 
-        <p>DCAT is formulated as an RDF vocabulary and is expected to remain so, however, as with all earlier work, the working Group is agnostic about data formats. Methods for expressing DCAT in other (existing) formats are in scope.</p>
-        <p>Government data, scientific research data, industry/enterprise and cultural heritage data, whether shared openly or not, are all explicitly in scope.  The working group will primarily look at cross-domain requirements.</p>
+        <p>RDF and compatible/comparable data formats; government data, scientific research data, industry/enterprise and cultural heritage data, cross-domain requirements and use cases.</p>
 
         <section id="input-documents">
           <h3>Input Documents</h3>
@@ -192,20 +191,21 @@
 
           <section>
             <h4>Existing Project Materials</h4>
-            <p>In the course of the first charter period of the Dataset Exchange Working Group material was developed which did not get used in the documents published as recommendations and notes, these include various things on  the <a href="https://github.com/w3c/dxwg">DXWG Github</a> and the <a href="https://www.w3.org/2017/dxwg/wiki/Main_Page">project wiki</a>, but particularly those Github issues marked as <a href="https://github.com/w3c/dxwg/issues?q=is%3Aopen+is%3Aissue+label%3Afuture-work">Future-work</a>.</p>
+            <p>Documents, recommendations and notes on  the <a href="https://github.com/w3c/dxwg">DXWG Github</a> and the <a href="https://www.w3.org/2017/dxwg/wiki/Main_Page">project wiki</a>, Github issues marked as <a href="https://github.com/w3c/dxwg/issues?q=is%3Aopen+is%3Aissue+label%3Afuture-work">Future-work</a>.</p>
           </section>
           <section>
             <h4>W3C documents</h4>
             <ul>
-              <li><a href="https://www.w3.org/TR/2019/CR-vocab-dcat-2-20191003/">DCAT version 2</a> and the <a href="https://www.w3.org/TR/hcls-dataset/">HCLS Community profile</a></li>
+              <li><a href="https://www.w3.org/TR/vocab-dcat-3/">DCAT version 3</a> and the <a href="https://www.w3.org/TR/hcls-dataset/">HCLS Community profile</a></li>
               <li>The <a href="https://www.w3.org/TR/vocab-dqv/">Data Quality</a> and <a href="https://www.w3.org/TR/vocab-duv/">Dataset Usage</a> vocabularies</li>
-              <li>The Smart Data &amp; Smarter Descriptions (SDSVoc) <a href="https://www.w3.org/2016/11/sdsvoc/report">workshop report</a>, in particular the section on content negotiation by application profile.</li>
               <li><a href="https://www.w3.org/TR/dwbp/">Data on the Web Best Practices</a></li>
+              <li>The <a href="https://www.w3.org/TR/tabular-metadata/">Metadata Vocabulary for Tabular Data</a> commonly known as CSV on the Web</li>
+              <li>The <a href="https://www.w3.org/TR/vocab-data-cube/">RDF Data Cube Vocabulary</a> for publishing multi-dimensional data, such as statistics, on the web</li> 
             </ul>
           </section>
           <section>
             <h4>Non-W3C documents</h4>
-            <p>DCAT must take account of current practice in many different communities. The following list is therefore not exhaustive.</p>
+            <p>The WG must take account of current practice in many different communities. The following list is therefore not exhaustive.</p>
             <ul>
               <li><a href="https://joinup.ec.europa.eu/asset/dcat_application_profile/description">DCAT-AP</a> and related work, such as <a href="https://doc.difi.no/dcat-ap-no/">DCAT-AP-NO</a>, <a href="https://www.dati.gov.it/content/dcat-ap-it-v10-profilo-italiano-dcat-ap-0">DCAT-AP-IT</a>, <a href="https://joinup.ec.europa.eu/solution/geodcat-application-profile-data-portals-europe">GeoDCAT-AP</a>, <a href="https://www.dcat-ap.de/">DCAT-AP.de</a> etc. </li>
               <li><a href="http://schema.org/Dataset">schema.org's dataset description</a> vocabulary;</li>
@@ -213,9 +213,10 @@
                 <a href="http://www.eurocris.org/cerif/main-features-cerif">CERIF</a> (the Common European Research Information Format),
                 <a href="http://wiki.dbpedia.org/projects/dbpedia-dataid">DBpedia DataID</a>,
                 <a href="http://www.ddialliance.org/explore-documentation">DDI</a> (the Data Documentation Initiative),
+                <a href="https://mlcommons.org/working-groups/data/croissant/">Croissant</a> (an MLCommons specification for machine learning datasets),
                 <a href="https://www.datacite.org/">DataCite</a>,
                 <a href="https://www.iotone.com/organization/hypercat/o153">Hypercat</a> etc.</li>
-              <li>The <a href="https://www.force11.org/group/fairgroup/fairprinciples">FAIR Principles</a> (a community-based movement to make data assets findable, accessible, interoperable and reusable).</li>
+              <li>The <a href="https://www.force11.org/group/fairgroup/fairprinciples">FAIR Principles</a> (a community-based movement to make data assets findable, accessible, interoperable and reusable). In particular, research data object exchange specifications such as <a href="https://www.researchobject.org/ro-crate/">Research Object Crates</a> (RO-Crates).</li>
               <li id="dsp"><a href="http://dublincore.org/documents/dc-dsp/">Description Set Profiles</a> (constraint language for Dublin Core Application Profiles).</li>
             </ul>
           </section>
@@ -233,7 +234,7 @@
           Deliverables
         </h2>
 
-        <p class=todo>UPDATE THIS SECTION</p>
+        <!-- <p class=todo>UPDATE THIS SECTION</p>
         <ul class=todo>
           <li>Update the entry about DCAT to link to DCAT 3 explicitly state "maintenance"
           <li>Add entry for the maintenance of Data Cube
@@ -241,7 +242,7 @@
               <li>Publish technical notes on bindings between VVD and other related W3C and non-W3C standards (DDI-CDI, RDF Data Cube, COW, SSN/SOSA, R2ML, etc).
               <li>Establish a list of use cases for the use of VVD, possibly in combination with related standards.
             </ul>
-        </ul>
+        </ul> -->
 
         <p>Updated document status is available on the <a href="https://www.w3.org/groups/wg/dx/publications">group publication status page</a>.</p>
 
@@ -258,18 +259,29 @@
             <dt id="dcat3" class="spec"><a href="https://www.w3.org/TR/vocab-dcat-3/">Data Catalog Vocabulary (DCAT) - Version 3</a></dt>
             <dd>
               <p>DCAT is an RDF vocabulary designed to facilitate interoperability between data catalogs published on the Web. This document defines the schema and provides examples for its use.</p>
-              <p>An update and expansion of the <a href="https://www.w3.org/TR/vocab-dcat-2/">current DCAT Recommendation</a>. The new version may deprecate features, but <span class="rfc21192">MUST</span> maintain backwards compatibility.</p>
-              <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/2022/WD-vocab-dcat-3-20220111/">Working Draft</a></p>
-              <p class="milestone"><b>Expected completion:</b> Q1 2023</p>
-                <p><b>Adopted Draft:</b> <a href="https://www.w3.org/TR/2022/WD-vocab-dcat-3-20220111/">Data Catalog Vocabulary (DCAT) - Version 3, W3C Working Draft 11 January 2022</a>
+              <p>Maintenance of the <a href="https://www.w3.org/TR/vocab-dcat-3/">current DCAT-3 Recommendation</a>.</p>
+              <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/vocab-dcat-3/">Maintenance</a></p>
+              <p class="milestone"><b>Expected completion:</b> Not specified</p>
+              <!--   <p><b>Adopted Draft:</b> <a href="https://www.w3.org/TR/2022/WD-vocab-dcat-3-20220111/">Data Catalog Vocabulary (DCAT) - Version 3, W3C Working Draft 11 January 2022</a>
               <p><b>Exclusion Draft:</b> <a href='https://www.w3.org/TR/2020/WD-vocab-dcat-3-20201217/'>Data Catalog Vocabulary (DCAT) - Version 3, W3C Working Draft 17 December 2021</a>.
                 associated <a href='https://www.w3.org/mid/cfe-7714-d5c022bcd7cbefe82175c52dd9ad5a8cf1756fc9@w3.org'>Call for Exclusion</a> on 2020-12-17 ended on 2021-05-16.<br>
-                <b>Exclusion Draft Charter:</b> <a href='https://www.w3.org/2020/02/dx-wg-charter.html'>https://www.w3.org/2020/02/dx-wg-charter.html</a>
+                <b>Exclusion Draft Charter:</b> <a href='https://www.w3.org/2020/02/dx-wg-charter.html'>https://www.w3.org/2020/02/dx-wg-charter.html</a> -->
+            </dd>
+            <dt id="qb" class="spec"><a href="https://www.w3.org/TR/vocab-data-cube/">RDF Data Cube Vocabulary (QB)</a></dt>
+            <dd>
+              <p>The Data Cube vocabulary provides means to publish multi-dimensional data, such as statistics, on the web in such a way that it can be linked to related data sets and concepts. This document defines the schema and provides examples for its use. </p>
+              <p>Maintenance of the <a href="https://www.w3.org/TR/vocab-data-cube/">current QB Recommendation</a></p>
+              <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/vocab-data-cube/">Maintenance</a></p>
+              <p class="milestone"><b>Expected completion:</b> Not specified</p>
+              <!--   <p><b>Adopted Draft:</b> <a href="https://www.w3.org/TR/2022/WD-vocab-dcat-3-20220111/">Data Catalog Vocabulary (DCAT) - Version 3, W3C Working Draft 11 January 2022</a>
+              <p><b>Exclusion Draft:</b> <a href='https://www.w3.org/TR/2020/WD-vocab-dcat-3-20201217/'>Data Catalog Vocabulary (DCAT) - Version 3, W3C Working Draft 17 December 2021</a>.
+                associated <a href='https://www.w3.org/mid/cfe-7714-d5c022bcd7cbefe82175c52dd9ad5a8cf1756fc9@w3.org'>Call for Exclusion</a> on 2020-12-17 ended on 2021-05-16.<br>
+                <b>Exclusion Draft Charter:</b> <a href='https://www.w3.org/2020/02/dx-wg-charter.html'>https://www.w3.org/2020/02/dx-wg-charter.html</a> -->
             </dd>
             <dt id="conneg" class="spec"><a href="https://www.w3.org/TR/dx-prof-conneg/">Content Negotiation by Profile</a></dt>
             <dd>
               <p>This document describes how Internet clients may negotiate for content provided by servers based on data profiles to which the content conforms. This is distinct from negotiating by Media Type or Language: a profile may specify the content of information returned, which may be a subset of the information the responding server has about the requested resource, and may be structured in a specific way to meet interoperability requirements of a community of practice.</p>
-              <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/2019/WD-dx-prof-conneg-20191126/">Working Draft</a></p>
+              <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/2023/WD-dx-prof-conneg-20231002/">Working Draft</a></p>
               <p class="milestone"><b>Expected completion:</b> Not specified</p>
               <p><b>Adopted Draft:</b> <a href="https://www.w3.org/TR/2019/WD-dx-prof-conneg-20191126/">Content Negotiation by Profile,
                 W3C Working Draft 26 November 2019</a>
@@ -287,9 +299,11 @@
             Other non-normative documents may be created such as:
           </p>
           <ul>
-            <li>A use case and requirements document</li>
+            <li>A specification for the variable description vocabulary (VVD)</li>
+            <li>A use case and requirements document for the use of VVD, possibly in combination with related standards.</li>
+            <li>Technical notes on bindings between VVD and other related W3C and non-W3C standards (DDI-CDI, RDF Data Cube, COW, SSN/SOSA, R2ML, etc)</li>
             <li>A test suite for content negotiation by application profile</li>
-            <li>A primer on the uses of DCAT</li>
+            <!-- <li>A primer on the uses of DCAT</li> -->
             <li>Guidance on publishing application profiles of vocabularies.</li>
             <li>Subject to its capacity, the working group may choose to develop additional relevant vocabularies in response to community demand.</li>
           </ul>
@@ -297,14 +311,15 @@
 
         <section id="timeline">
           <h3>Timeline</h3>
-            <p class="todo">Put here a timeline view of all deliverables.</p>
-            <ul class="todo">
-              <li>Month YYYY: First teleconference</li>
-              <li>Month YYYY: First face-to-face meeting</li>
-              <li>Month YYYY: Requirements and Use Cases for FooML</li>
-              <li>Month YYYY: FPWD for FooML</li>
-              <li>Month YYYY: Requirements and Use Cases for BarML</li>
-              <li>Month YYYY: FPWD FooML Primer</li>
+            <!-- <p class="todo">Put here a timeline view of all deliverables.</p> -->
+            <ul>
+              <li>September 2025: First teleconference</li>
+              <li>November 2025: First face-to-face meeting</li>
+              <li>April 2026: Requirements and Use Cases for VVD</li>
+              <li>August 2026: FPWD for VVD</li>
+              <li>November 2026: Second face-to-face meeting</li>
+              <li>April 2027: Bindings between VVD and other W3C/non-W3C specifications</li>
+              <li>August 2027: Guidance on publishing variable descriptions with VVD</li>
             </ul>
         </section>
       </section>
@@ -364,16 +379,24 @@ interoperability can be verified by passing open test suites.</p>
         <section>
           <h3 id="w3c-coordination">W3C Groups</h3>
 
-          <p class=todo>CHECK THIS SECTION, AND UPDATE IF NECESSARY</p>
+          <!-- <p class=todo>CHECK THIS SECTION, AND UPDATE IF NECESSARY</p> -->
 
           <dl>
-            <dt><a href="https://www.w3.org/community/shex/">Shape Expressions Community Group</a></dt>
-            <dd><p>The work of this CG is of direct relevance to the concept of application profiles.</p></dd>
-            <dt><a href="https://www.w3.org/community/shacl/">SHACL Community Group</a></dt>
-            <dd><p>This CG is continuing work on the W3C <a href="https://www.w3.org/TR/shacl/">Shapes Constraint Language</a> Recommendation.  Efforts should be made to liaise with its community.</p></dd>
-
+            <dt><a href="https://www.w3.org/groups/wg/data-shapes/">Data Shapes Working Group</a></dt>
+            <dd><p>The work of this WG produces the W3C <a href="https://www.w3.org/TR/shacl/">Shapes Constraint Language</a> Recommendation.  Efforts should be made to liaise with its community.</p></dd>
+            
             <dt><a href="https://www.w3.org/community/schemaorg4datasets/">schema.org for datasets Community Group</a></dt>
             <dd><p>This CG is clearly of high relevance to the DXWG</p></dd>
+
+            <dt><a href="https://www.w3.org/groups/wg/json-ld/">JSON-LD Working Group</a></dt>
+            <dd><p>JSON-LD is a key technology for the publication of datasets on the Web, and so the DXWG should coordinate with the JSON-LD WG to ensure that any new features in DCAT, QB or VVD are can be easily represented with JSON-LD.</p></dd>
+
+            <dt><a href="https://www.w3.org/groups/wg/rdf-star/">RDF & SPARQL Working Group</a></dt>
+            <dd><p>DXWG should coordinate with the RDF and SPARQL specifications to ensure that any new features in DCAT, QB or VVD are can be easily represented with RDF-star and queried in SPARQL.</p></dd>
+
+            <dt><a href="https://www.w3.org/groups/wg/webmachinelearning">Web Machine Learning Working Group</a></dt>
+            <dd><p>Datasets that use DCAT, QB or VVD should be easily consumed in ML workflows and used for inference.</p></dd>
+            
 
             <dt id="odrl"><a href="https://www.w3.org/community/odrl/">Open Digital Rights Language (ODRL) Community Group</a></dt>
             <dd><p>Ensure that the mechanisms of the W3C <a href="https://www.w3.org/TR/odrl-vocab/">ODRL</a> Recommendation being maintained by the ODRL Community Group for machine readable permissions, obligations, licenses, rights etc. are given due consideration.</p></dd>
@@ -388,9 +411,17 @@ interoperability can be verified by passing open test suites.</p>
         <section>
           <h3 id="external-coordination">External Organizations</h3>
 
-          <p class=todo>CHECK THIS SECTION, AND UPDATE IF NECESSARY</p>
+          <!-- <p class=todo>CHECK THIS SECTION, AND UPDATE IF NECESSARY</p> -->
 
           <dl>
+            <dt><a href="https://ddialliance.org/">DDI Alliance</a></dt>
+            <dd>
+                <p>The DDI Alliance is an international membership organization that creates and maintains technical standards for describing research data in the social, demographic, economic, and health sciences such as <a href="https://ddialliance.org/ddi-cdi">DDI Cross-Domain Integration (DDI-CDI)</a>.</p>
+            </dd>
+            <dt><a href="https://mlcommons.org/">MLCommons</a></dt>
+            <dd>
+                <p>MLCommons is an Artificial Intelligence engineering consortium, built on a philosophy of open collaboration to improve AI systems by proposing standards such as <a href="https://mlcommons.org/working-groups/data/croissant/">Croissant</a>.</p>
+            </dd>
             <dt><a href="https://ec.europa.eu/isa2/">European Commission's ISA Programme</a></dt>
             <dd>
                 <p>This is the body responsible for interoperability across the EU and whose outputs include various application profiles of DCAT such as <a href="https://joinup.ec.europa.eu/asset/dcat_application_profile/description">DCAT-AP</a>, <a href="https://joinup.ec.europa.eu/node/154143/">GeoDCAT-AP</a> and <a href="https://joinup.ec.europa.eu/node/147940">StatDCAT-AP</a>.</p>
@@ -443,8 +474,8 @@ interoperability can be verified by passing open test suites.</p>
           Most Dataset Exchange Working Group teleconferences will focus on discussion of particular specifications, and will be conducted on an as-needed basis.
         </p>
         <p>
-          This group primarily conducts its technical work  <i class="todo">pick one, or both, as appropriate (NB: the previous charter only mentions the mailing list, but in practice github is being increasingly used, so at least I think we should keep both):</i> on the public mailing list <a id="public-name" href="mailto:public-dxwg-wg@w3.org">public-dxwg-wg@w3.org</a> (<a href="https://lists.w3.org/Archives/Public/public-dxwg-wg/">archive</a>)
-          <i class="todo">or</i> on <a id="public-github" href="https://github.com/w3c/dx-wg-charter">GitHub issues</a>.
+          This group primarily conducts its technical work:</i> on the public mailing list <a id="public-name" href="mailto:public-dxwg-wg@w3.org">public-dxwg-wg@w3.org</a> (<a href="https://lists.w3.org/Archives/Public/public-dxwg-wg/">archive</a>)
+          <i class="bold">and</i> on <a id="public-github" href="https://github.com/w3c/dx-wg-charter/issues">GitHub issues</a>.
           The public is invited to review, discuss and contribute to this work.
         </p>
         <p>


### PR DESCRIPTION
Updated the previous draft:

- Revised and shortened motivation to include VVD and link to DCAT and QB
- Reduced scope
- Input docs: Added QB to W3C and Croissant to non-W3C
- Updated deliverables
- Updated list of W3C WGs in coordination
- Added DDI and MLCommons to external organisations
- Comms: Kept both email and GitHub issues to make sure that’s not a bottleneck to participation

A few questions:
- I assumed 'non-deliverable' for VVD means non-normative, please let me know otherwise
- Removed fields for normative specs (completion, adopted, exclusion), are links to  the current spec as maintenance doc ok?
- I left content negotiation by profile as normative spec since I assumed the charter is carryin on that one
- For non-deliverables, removed DCAT related stuff but left the content negotiation entries
- In the timeline, made the f2f meetings coincide with Dagstuhl meetings, is this a good idea? I guess not everyone will be able to make it but it would give the meeting a lot of purpose
- Is 1 year timeline for VVD good? And invest the 2nd year for bindings and use?